### PR TITLE
Fix soil moisture sensor naming to support channels 9-16

### DIFF
--- a/custom_components/ecowitt_local/const.py
+++ b/custom_components/ecowitt_local/const.py
@@ -382,7 +382,7 @@ SENSOR_TYPES.update(_generate_channel_sensors(
     {"unit": "%", "device_class": "humidity"}, 8
 ))
 SENSOR_TYPES.update(_generate_channel_sensors(
-    "soilmoisture", "Soil Moisture",
+    "soilmoisture", "Soil Moisture CH{ch}",
     {"unit": "%", "device_class": "moisture"}, 16
 ))
 SENSOR_TYPES.update(_generate_channel_sensors(
@@ -494,7 +494,7 @@ BATTERY_SENSORS: Final = {
 
 # Add dynamically generated battery sensors
 BATTERY_SENSORS.update(_generate_battery_sensors(
-    "soilbatt", "Battery", "soilmoisture{ch}", 16
+    "soilbatt", "Soil Moisture CH{ch} Battery", "soilmoisture{ch}", 16
 ))
 BATTERY_SENSORS.update(_generate_battery_sensors(
     "batt", "Temperature/Humidity CH{ch} Battery", "temp{ch}f", 8

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -130,7 +130,7 @@ async def test_sensor_unique_id_with_hardware_id(mock_coordinator):
         "sensor_key": "soilmoisture1",
         "hardware_id": "D8174",
         "category": "sensor",
-        "name": "Soil Moisture",
+        "name": "Soil Moisture CH1",
         "state": 50
     }
     
@@ -357,7 +357,7 @@ async def test_device_info_with_hardware_id(mock_coordinator):
         "sensor_key": "soilmoisture1",
         "hardware_id": "D8174",
         "category": "sensor",
-        "name": "Soil Moisture",
+        "name": "Soil Moisture CH1",
         "state": 50
     }
     
@@ -390,7 +390,7 @@ async def test_device_info_invalid_hardware_id(mock_coordinator):
         "sensor_key": "soilmoisture1",
         "hardware_id": "FFFFFFFE",  # Invalid hardware ID
         "category": "sensor",
-        "name": "Soil Moisture",
+        "name": "Soil Moisture CH1",
         "state": 50
     }
     
@@ -414,7 +414,7 @@ async def test_device_info_no_sensor_info(mock_coordinator):
         "sensor_key": "soilmoisture1",
         "hardware_id": "D8174",
         "category": "sensor",
-        "name": "Soil Moisture", 
+        "name": "Soil Moisture CH1", 
         "state": 50
     }
     
@@ -494,7 +494,7 @@ async def test_extra_state_attributes_hardware(mock_coordinator):
         "sensor_key": "soilmoisture1",
         "hardware_id": "D8174",
         "category": "sensor",
-        "name": "Soil Moisture",
+        "name": "Soil Moisture CH1",
         "state": 50,
         "attributes": {
             "channel": "1",
@@ -530,7 +530,7 @@ async def test_extra_state_attributes_invalid_values(mock_coordinator):
         "sensor_key": "soilmoisture1",
         "hardware_id": "D8174",
         "category": "sensor", 
-        "name": "Soil Moisture",
+        "name": "Soil Moisture CH1",
         "state": 50,
         "attributes": {
             "battery": "invalid",
@@ -673,7 +673,7 @@ async def test_available_hardware_sensor_none_state(mock_coordinator):
         "sensor_key": "soilmoisture1",
         "hardware_id": "D8174",
         "category": "sensor",
-        "name": "Soil Moisture",
+        "name": "Soil Moisture CH1",
         "state": None
     }
     
@@ -697,7 +697,7 @@ async def test_available_hardware_sensor_none_state_include_inactive(mock_coordi
         "sensor_key": "soilmoisture1",
         "hardware_id": "D8174",
         "category": "sensor",
-        "name": "Soil Moisture",
+        "name": "Soil Moisture CH1",
         "state": None
     }
     


### PR DESCRIPTION
## Summary

This PR fixes the soil moisture sensor identification issue for channels 9-16 by adding channel numbers to sensor names. This ensures all 16 soil moisture channels are properly distinguishable in the Home Assistant UI.

## Problem

As reported in issue #23, while the integration supports up to 16 soil moisture sensor channels (consistent with soil battery support), users could not distinguish between sensors on channels 9-16 because all sensors had the same generic name "Soil Moisture".

## Solution

- Updated soil moisture sensor names from `'Soil Moisture'` to `'Soil Moisture CH{ch}'`
- Updated soil battery sensor names from `'Battery'` to `'Soil Moisture CH{ch} Battery'`
- This naming convention is consistent with other sensor types (temperature, humidity, etc.) used in the integration
- Updated tests to reflect the new naming convention

## Changes Made

### Files Modified:
- `custom_components/ecowitt_local/const.py` - Updated sensor naming templates
- `tests/test_sensor.py` - Updated test cases to match new naming convention

### Implementation Details:
The sensor name templates now include the channel number:
- Soil moisture sensors: `"Soil Moisture CH{ch}"`
- Soil battery sensors: `"Soil Moisture CH{ch} Battery"`

This allows users to easily identify and differentiate between all 16 soil moisture channels in their Home Assistant dashboard.

## Testing

- Updated existing unit tests to verify new naming convention
- All tests pass with the new changes

## Related Issues

Fixes #23

## Reference

This implementation aligns with best practices observed in similar integrations while maintaining consistency with the existing naming patterns used by other multi-channel sensors in this integration.