### PR TITLE
Remove redundant merge logic from auto-pr.yml

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -142,20 +142,5 @@ jobs:
             echo "⚠️ PR creation failed - may already exist"
             exit 0  # Exit successfully to avoid failing the workflow
           fi
-
-          # CI already passed on this branch — merge immediately.
-          # GitHub prevents GITHUB_TOKEN-created PRs from triggering downstream
-          # pull_request events, so auto-merge.yml can never fire via that route.
-          PR_NUMBER=$(gh pr list --head "$BRANCH" --base main --json number --jq '.[0].number')
-          if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
-            echo "Merging PR #${PR_NUMBER}..."
-            gh pr merge "$PR_NUMBER" \
-              --merge \
-              --delete-branch \
-              --subject "Merge release PR #${PR_NUMBER}: Release v${VERSION}" \
-              --body "Automatically merged after CI passed on ${BRANCH}." \
-            && echo "✅ PR #${PR_NUMBER} merged" \
-            || echo "⚠️ Merge failed (may require manual merge)"
-          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Removes the `gh pr merge` block that was accidentally merged into `auto-pr.yml` via PR #65.

`auto-merge.yml` already handles merging via `check_suite` events and works correctly. The extra merge call in `auto-pr.yml` created a race condition where both workflows could try to merge the same PR simultaneously.

This is a cleanup-only change — no version bump needed.