### PR TITLE
Fix auto-merge workflow trigger

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,14 +1,8 @@
 name: Auto Merge Release PRs
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches:
-      - main
-  check_suite:
-    types: [completed]
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["Auto PR for Claude Branches"]
     types: [completed]
 
 permissions:
@@ -18,34 +12,46 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    # Only auto-merge PRs from claude branches with release label or release title
+    # Only run after auto-pr succeeds on a claude/release-* branch
     if: |
-      github.event.pull_request.head.ref != null &&
-      startsWith(github.event.pull_request.head.ref, 'claude/') &&
-      (contains(github.event.pull_request.labels.*.name, 'release') || startsWith(github.event.pull_request.title, 'Release v'))
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'claude/release-')
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Wait for all checks to complete
-        uses: lewagon/wait-on-check-action@v1.3.1
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          check-regexp: '(test \(3\.(11|12)\)|validate|HACS Action)'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-          allowed-conclusions: success
-
-      - name: Auto-merge PR
+      - name: Find and merge release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_NUMBER="${{ github.event.pull_request.number }}"
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          echo "Looking for release PR from branch: $BRANCH"
 
-          # Merge the PR
+          PR_NUMBER=$(gh pr list \
+            --head "$BRANCH" \
+            --base main \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty' \
+            --repo "${{ github.repository }}")
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "⏭️ No open PR found for branch $BRANCH - skipping"
+            exit 0
+          fi
+
+          PR_TITLE=$(gh pr view "$PR_NUMBER" --json title --jq '.title' --repo "${{ github.repository }}")
+          echo "Found PR #$PR_NUMBER: $PR_TITLE"
+
+          if ! echo "$PR_TITLE" | grep -qE "^Release v"; then
+            echo "⏭️ PR #$PR_NUMBER is not a release PR - skipping"
+            exit 0
+          fi
+
+          echo "✅ Merging release PR #$PR_NUMBER"
           gh pr merge "$PR_NUMBER" \
             --merge \
             --delete-branch \
             --subject "Merge release PR #${PR_NUMBER}" \
-            --body "Automatically merged by GitHub Actions after all checks passed."
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            --body "Automatically merged by GitHub Actions after all checks passed." \
+            --repo "${{ github.repository }}"
+
+          echo "✅ PR #$PR_NUMBER merged successfully"


### PR DESCRIPTION
## Fix: Auto Merge Release PRs workflow never fires

### Root cause

All three triggers in `auto-merge.yml` were broken for GITHUB_TOKEN-created PRs:

- **`pull_request`**: GitHub does not fire `pull_request` events for PRs created by `GITHUB_TOKEN`.
- **`workflow_run: CI`**: Fires before the PR even exists; the `if` condition checked `github.event.pull_request.head.ref` which is always `null` in a `workflow_run` context → always skipped.
- **`check_suite`**: Same `pull_request.*` null problem in the `if` condition.

### Fix

Trigger exclusively from `workflow_run: ["Auto PR for Claude Branches"]`. By the time auto-pr completes, the PR already exists. Use `gh pr list` to find the PR by branch name and merge it directly. Removed `lewagon/wait-on-check-action` — all checks already passed on the branch before auto-pr ran.

### Pipeline (after fix)
1. CI passes on `claude/release-*` → **auto-pr.yml** creates PR
2. auto-pr.yml completes → **auto-merge.yml** fires, finds PR, merges it
3. Merge triggers **auto-release.yml** via `workflow_run` → creates tag + GitHub release

---
*Infrastructure PR — no version bump required.*