### PR TITLE
Configure claude-code-action with project context

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -29,3 +29,10 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          custom_instructions: |
+            Read CLAUDE.md for full project context before doing anything.
+            Always create a branch named claude/issue-{number}-{short-description}.
+            Always run tests before creating a PR: PYTHONPATH="$PWD" .venv/bin/pytest tests/ -v
+            Set up the venv first if needed: python3 -m venv .venv && .venv/bin/pip install -r requirements_test.txt
+            Do NOT implement WH77 support - it is a testing sensor only.
+            Do NOT auto-merge PRs - create the PR and leave it for review.


### PR DESCRIPTION
Adds `custom_instructions` to the claude-code-action so it:
- Reads `CLAUDE.md` for full project context before doing anything
- Names branches consistently (`claude/issue-{number}-{description}`)
- Runs tests before creating a PR
- Avoids known pitfalls (WH77, auto-merging)

**To activate:** add `ANTHROPIC_API_KEY` to repo Settings → Secrets → Actions.

Once set, commenting `@claude fix this` on any issue will trigger Claude to implement a fix and open a PR for review.

---
*Infrastructure PR — no version bump required.*