### PR TITLE
Fix claude-code-action: image viewing + remove deprecated param

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--model claude-sonnet-4-6"
           prompt: |
             Read CLAUDE.md for full project context first.
 
@@ -30,8 +31,18 @@ jobs:
             Issue body:
             ${{ github.event.issue.body }}
 
+            IMPORTANT - Images and attachments:
+            The issue body above may contain image URLs in markdown format like
+            ![description](https://github.com/user-attachments/assets/...).
+            For every image URL found, download it with:
+              curl -sL "<url>" -o /tmp/issue_img_<N>.png
+            Then view each downloaded file using the Read tool — images often
+            contain critical diagnostic data (screenshots, sensor readings, logs)
+            not described in the text.
+
             Your task:
-            1. Analyse the issue and determine whether it is an actionable bug or feature request.
+            1. Analyse the issue (including any images) and determine whether it
+               is an actionable bug or feature request.
             2. If it is actionable, implement a fix on a new branch named
                claude/issue-${{ github.event.issue.number }}-<short-description>.
             3. Set up the test environment first if needed:
@@ -40,12 +51,10 @@ jobs:
                PYTHONPATH="$PWD" .venv/bin/pytest tests/ -v
             5. Bump the patch version in manifest.json and add a CHANGELOG.md entry.
             6. Open a PR targeting main. Do NOT comment on the issue itself.
-            7. If the issue is not actionable (e.g. a question, duplicate, or needs more info),
-               do nothing — do not comment, do not create a branch.
+            7. If the issue is not actionable (e.g. a question, duplicate, or
+               needs more info), do nothing — do not comment, do not create a branch.
 
             Important constraints:
             - Do NOT implement WH77 support (it is a test sensor only).
             - Do NOT auto-merge the PR — leave it open for review.
-          claude_args: "--model claude-sonnet-4-6"
-          custom_instructions: |
-            Do not post any comments on GitHub issues. Only create branches and PRs.
+            - Do NOT post any comments on the issue.


### PR DESCRIPTION
Two fixes:

1. **`custom_instructions` is deprecated** — moved the no-comments constraint into `prompt` directly
2. **Images not being viewed** — added explicit instructions to download image attachments with `curl` and view them with the `Read` tool. Issue screenshots often contain the only useful diagnostic data (sensor readings, entity lists, etc.)

---
*Infrastructure PR — no version bump required.*