### PR TITLE
Fix claude-code-action: use GITHUB_TOKEN to bypass OIDC check

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: "--model claude-sonnet-4-6"
           prompt: |
             Read CLAUDE.md for full project context first.


### PR DESCRIPTION
The action was failing with `401 Unauthorized - User does not have write access` when triggered by external users opening issues. The OIDC→App token exchange checks if the *triggering actor* has write access — external issue reporters don't. Fix: pass `github_token: ${{ secrets.GITHUB_TOKEN }}` so the action uses the workflow's own token instead.