### PR TITLE
fix(release): show actual CHANGELOG content in HACS release notes

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -81,13 +81,15 @@ jobs:
           if [ -f CHANGELOG.md ]; then
             echo "📄 Found CHANGELOG.md, extracting notes for version $VERSION"
             
-            # Extract the section for this version
-            # Get content between version header and next version header (or end)
-            awk "/## \[$VERSION\]/,/^## \[/ {
-              if (/^## \[$VERSION\]/) next;
-              if (/^## \[/) exit;
-              print
-            }" CHANGELOG.md > "$NOTES_FILE"
+            # Extract the section for this version using a state-machine.
+            # Range form `/start/,/end/` fails here because the start line also matches
+            # the end pattern (`^## \[`), so the range activates and deactivates on the
+            # same line and nothing gets printed.
+            awk -v ver="$VERSION" '
+              $0 ~ "^## \\[" ver "\\]" { in_section = 1; next }
+              in_section && /^## \[/ { exit }
+              in_section { print }
+            ' CHANGELOG.md > "$NOTES_FILE"
             
             # Remove leading/trailing empty lines
             sed -i '/./,$!d' "$NOTES_FILE"


### PR DESCRIPTION
## Summary

- The CHANGELOG-extraction awk in `auto-release.yml` was using a buggy range expression — start line `## [VERSION]` also matched the end pattern `^## \[`, so the range activated/deactivated on the same line and produced 0 bytes
- Every release silently fell back to the generic "This release includes updates and improvements" message that HA users saw in HACS
- Replaced with a state-machine that enters on the version header and exits on the next `## [` header
- Verified locally on v1.6.19 — extracts 716 chars of real changelog content

Takes effect on the next release. Existing release bodies left as-is (HACS caches them).

## Test plan

- [ ] CI passes
- [ ] Next release after merge shows the actual CHANGELOG section in the GitHub release body and in HACS update notifications