### PR TITLE
Release v1.7.24 - reconfigure flow and MAC-based unique_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ htmlcov/
 venv/
 env/
 .venv/
+.venv-wsl/
 
 # IDE files
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.24] - 2026-09-05
+
+### Added
+- **Reconfigure flow**: the gateway's IP address (and password) can now be updated from the Home Assistant UI without removing and re-adding the integration, so existing devices, entities, and any automations that reference them are preserved. Previously the only way to move to a new IP after a DHCP lease change was to delete and recreate the config entry.
+- **MAC-based unique ID**: when the gateway exposes its network info (`/get_network_info`), its MAC address — stable across IP changes, unlike the host address previously used — becomes the config entry's unique ID. Gateways where this isn't available fall back to the previous model+host scheme. Existing (legacy) entries transparently adopt the MAC-based ID the first time they're reconfigured; the strict "same physical device" check only applies once both the old and new IDs are MAC-based, so this upgrade never triggers a false "wrong device" abort.
+
+### Fixed
+- **Gateway model always showed as "Unknown" in the config flow on gateways that omit `stationtype` from `/get_version`**: some real-world gateways report only a `version` string (e.g. `"Version: GW1100A_V2.4.5"`) with no dedicated `stationtype` field. The config flow now falls back to parsing the model out of that string, reusing the same parsing already relied on elsewhere in the integration for the live gateway device info.
+
 ## [1.7.23] - 2026-09-04
 
 ### Fixed

--- a/custom_components/ecowitt_local/api.py
+++ b/custom_components/ecowitt_local/api.py
@@ -344,6 +344,27 @@ class EcowittLocalAPI:
         """
         return await self._make_request("/get_version")
 
+    async def get_network_info(self) -> Dict[str, Any]:
+        """Get gateway network information.
+
+        Includes the gateway's MAC address, which — unlike the IP address —
+        does not change when the gateway gets a new DHCP lease, making it a
+        good basis for a stable identifier. Not all gateway models are
+        confirmed to expose this endpoint.
+
+        The response also includes the configured Wi-Fi password (base64
+        encoded). Callers must only read the fields they need (e.g. `mac`)
+        and must never log or persist the full response.
+
+        Returns:
+            Network info dict; notably the `mac` field.
+
+        Raises:
+            ConnectionError: Network error
+            DataError: Invalid response data
+        """
+        return await self._make_request("/get_network_info")
+
     async def get_soil_calibration(self) -> List[Dict[str, Any]]:
         """Get soil moisture sensor calibration data including AD values.
 

--- a/custom_components/ecowitt_local/config_flow.py
+++ b/custom_components/ecowitt_local/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any, Dict, Optional
 
 import homeassistant.helpers.config_validation as cv
@@ -11,12 +12,13 @@ from homeassistant import config_entries, exceptions
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import device_registry as dr
 
 from .api import (
     AuthenticationError,
 )
 from .api import ConnectionError as APIConnectionError
-from .api import EcowittLocalAPI
+from .api import EcowittLocalAPI, EcowittLocalAPIError
 from .const import (
     CONF_INCLUDE_INACTIVE,
     CONF_MAPPING_INTERVAL,
@@ -29,6 +31,7 @@ from .const import (
     ERROR_INVALID_AUTH,
     ERROR_UNKNOWN,
 )
+from .coordinator import extract_model_from_firmware
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,6 +54,18 @@ STEP_OPTIONS_DATA_SCHEMA = vol.Schema(
     }
 )
 
+# A previously-generated unique_id that is a normalized MAC address, used to
+# tell a fresh MAC-based identifier apart from a legacy model+host one when
+# reconfiguring (see ConfigFlow.async_step_reconfigure).
+_MAC_UNIQUE_ID_RE = re.compile(r"^([0-9a-f]{2}:){5}[0-9a-f]{2}$")
+
+
+def _looks_like_mac(unique_id: Optional[str]) -> bool:
+    """Return True if unique_id is a normalized MAC address."""
+    if not unique_id:
+        return False
+    return bool(_MAC_UNIQUE_ID_RE.match(unique_id))
+
 
 async def validate_input(hass: HomeAssistant, data: Dict[str, Any]) -> Dict[str, Any]:
     """Validate the user input allows us to connect.
@@ -69,17 +84,39 @@ async def validate_input(hass: HomeAssistant, data: Dict[str, Any]) -> Dict[str,
         # Get basic info to validate the device
         version_info = await api.get_version()
 
-        # Extract gateway information
-        gateway_id = version_info.get("stationtype", "unknown")
-        model = version_info.get("stationtype", "Unknown")
+        # Older firmware (and this integration's test fixtures) reports a
+        # dedicated `stationtype` field. Gateways observed in the field
+        # instead omit it entirely and embed the model in the `version`
+        # string, e.g. "Version: GW1100A_V2.4.5".
+        stationtype = version_info.get("stationtype")
+        model = stationtype or extract_model_from_firmware(
+            version_info.get("version", "")
+        )
         firmware_version = version_info.get("version", "Unknown")
+
+        # The gateway's MAC address is a stable hardware identifier that
+        # survives IP address changes (e.g. a DHCP lease renewal), unlike
+        # the host-based identifier used as a fallback below. Not all
+        # gateway models are confirmed to support this endpoint, so a
+        # failure here is not fatal for the whole flow.
+        mac: Optional[str] = None
+        try:
+            network_info = await api.get_network_info()
+            raw_mac = network_info.get("mac")
+            if raw_mac:
+                mac = dr.format_mac(raw_mac)
+        except EcowittLocalAPIError:
+            mac = None
+
+        unique_id = mac if mac else f"{model}_{host}"
 
         return {
             "title": f"Ecowitt Gateway ({host})",
-            "gateway_id": gateway_id,
+            "unique_id": unique_id,
             "model": model,
             "firmware_version": firmware_version,
             "host": host,
+            "mac": mac,
         }
 
     except AuthenticationError:
@@ -123,7 +160,7 @@ class ConfigFlow(config_entries.ConfigFlow):
                 errors = {"base": ERROR_UNKNOWN}
             else:
                 # Check if already configured
-                await self.async_set_unique_id(f"{info['gateway_id']}_{info['host']}")
+                await self.async_set_unique_id(info["unique_id"])
                 self._abort_if_unique_id_configured()
 
                 # Store the validated info
@@ -168,6 +205,78 @@ class ConfigFlow(config_entries.ConfigFlow):
                 "scan_interval_desc": "How often to poll for live data (30-300 seconds)",
                 "mapping_interval_desc": "How often to refresh sensor mappings (5-60 minutes)",
                 "inactive_desc": "Include sensors that are currently offline",
+            },
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> FlowResult:
+        """Handle reconfiguration of an existing entry.
+
+        Lets the user update the gateway's IP address (and password) —
+        e.g. after a DHCP lease change — without removing and re-adding
+        the integration. Devices, entities, and any automations that
+        reference them are preserved.
+        """
+        errors: Optional[Dict[str, str]] = None
+        reconfigure_entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors = {"base": ERROR_CANNOT_CONNECT}
+            except InvalidAuth:
+                errors = {"base": ERROR_INVALID_AUTH}
+            except Exception:
+                _LOGGER.exception("Unexpected exception during reconfigure")
+                errors = {"base": ERROR_UNKNOWN}
+            else:
+                # The gateway's local HTTP API exposes a MAC address on
+                # most models (via /get_network_info), used here as a
+                # stable hardware identifier — but some older or
+                # unconfirmed models may not support that endpoint, and
+                # entries created before this identifier existed still
+                # carry the legacy model+host unique_id. Only apply the
+                # strict "same physical device" check when both the
+                # existing and the newly computed unique_id are
+                # MAC-based; otherwise this is either a gateway with no
+                # stable identifier, or a legacy entry being upgraded to
+                # one for the first time, and the unique_id is expected
+                # to change.
+                new_unique_id = info["unique_id"]
+                if info.get("mac") and _looks_like_mac(reconfigure_entry.unique_id):
+                    await self.async_set_unique_id(new_unique_id)
+                    self._abort_if_unique_id_mismatch(reason="wrong_device")
+                else:
+                    for entry in self._async_current_entries():
+                        if (
+                            entry.entry_id != reconfigure_entry.entry_id
+                            and entry.unique_id == new_unique_id
+                        ):
+                            return self.async_abort(reason="already_configured")
+
+                self.hass.config_entries.async_update_entry(
+                    reconfigure_entry,
+                    unique_id=new_unique_id,
+                    title=info["title"],
+                    data={**reconfigure_entry.data, **user_input},
+                )
+                await self.hass.config_entries.async_reload(reconfigure_entry.entry_id)
+                return self.async_abort(reason="reconfigure_successful")
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA,
+                {
+                    CONF_HOST: reconfigure_entry.data.get(CONF_HOST, ""),
+                    CONF_PASSWORD: reconfigure_entry.data.get(CONF_PASSWORD, ""),
+                },
+            ),
+            errors=errors,
+            description_placeholders={
+                "host_example": "192.168.1.100",
             },
         )
 

--- a/custom_components/ecowitt_local/coordinator.py
+++ b/custom_components/ecowitt_local/coordinator.py
@@ -37,6 +37,36 @@ from .sensor_mapper import SensorMapper
 _LOGGER = logging.getLogger(__name__)
 
 
+def extract_model_from_firmware(firmware_version: str) -> str:
+    """Extract gateway model from firmware version string.
+
+    Args:
+        firmware_version: Firmware version string (e.g., "GW1100A_V2.4.3")
+
+    Returns:
+        Gateway model (e.g., "GW1100A") or "Unknown" if extraction fails
+    """
+    if not firmware_version or firmware_version == "Unknown":
+        return "Unknown"
+
+    try:
+        # Some gateways prepend "Version: " to the version string (e.g. "Version: GW1100A_V2.4.3")
+        # Search for the GW model anywhere in the string to handle these cases.
+        # The model name ends at the first delimiter: underscore, dot, whitespace, or end of string.
+        match = re.search(r"\b(GW\w+?)(?=[_.\s]|$)", firmware_version)
+        if match:
+            return match.group(1)
+
+    except Exception as err:  # pragma: no cover
+        _LOGGER.debug(
+            "Error extracting model from firmware version '%s': %s",
+            firmware_version,
+            err,
+        )
+
+    return "Unknown"
+
+
 class EcowittLocalDataUpdateCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
     """Data coordinator for Ecowitt Local."""
 
@@ -1700,25 +1730,7 @@ class EcowittLocalDataUpdateCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
         Returns:
             Gateway model (e.g., "GW1100A") or "Unknown" if extraction fails
         """
-        if not firmware_version or firmware_version == "Unknown":
-            return "Unknown"
-
-        try:
-            # Some gateways prepend "Version: " to the version string (e.g. "Version: GW1100A_V2.4.3")
-            # Search for the GW model anywhere in the string to handle these cases.
-            # The model name ends at the first delimiter: underscore, dot, whitespace, or end of string.
-            match = re.search(r"\b(GW\w+?)(?=[_.\s]|$)", firmware_version)
-            if match:
-                return match.group(1)
-
-        except Exception as err:  # pragma: no cover
-            _LOGGER.debug(
-                "Error extracting model from firmware version '%s': %s",
-                firmware_version,
-                err,
-            )
-
-        return "Unknown"
+        return extract_model_from_firmware(firmware_version)
 
     async def async_refresh_mapping(self) -> None:
         """Force refresh of sensor mapping."""

--- a/custom_components/ecowitt_local/manifest.json
+++ b/custom_components/ecowitt_local/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/alexlenk/ecowitt_local/issues",
   "quality_scale": "platinum",
   "requirements": ["aiohttp>=3.8.0"],
-  "version": "1.7.23"
+  "version": "1.7.24"
 }

--- a/custom_components/ecowitt_local/strings.json
+++ b/custom_components/ecowitt_local/strings.json
@@ -26,6 +26,18 @@
           "mapping_interval": "How often to refresh sensor mappings (300-3600 seconds)",
           "include_inactive": "Include sensors that are currently offline or have no data"
         }
+      },
+      "reconfigure": {
+        "title": "Update Ecowitt Gateway Connection",
+        "description": "Update the connection details for this gateway, for example after its IP address changed.",
+        "data": {
+          "host": "Gateway IP Address",
+          "password": "Gateway Password (optional)"
+        },
+        "data_description": {
+          "host": "IP address or hostname of the Ecowitt gateway (e.g., 192.168.1.100)",
+          "password": "Password for the gateway web interface (leave blank if none)"
+        }
       }
     },
     "error": {
@@ -34,7 +46,9 @@
       "unknown": "Unexpected error occurred. Please try again."
     },
     "abort": {
-      "already_configured": "This gateway is already configured."
+      "already_configured": "This gateway is already configured.",
+      "reconfigure_successful": "The gateway connection was updated successfully.",
+      "wrong_device": "This IP address belongs to a different gateway than the one currently configured for this entry. Double-check the address, or remove this integration and add the other gateway separately."
     }
   },
   "options": {

--- a/custom_components/ecowitt_local/translations/da.json
+++ b/custom_components/ecowitt_local/translations/da.json
@@ -26,6 +26,18 @@
           "mapping_interval": "Hvor ofte sensorkortlægningen opdateres (300-3600 sekunder)",
           "include_inactive": "Medtag sensorer, der i øjeblikket er offline eller ikke har data"
         }
+      },
+      "reconfigure": {
+        "title": "Opdater forbindelse til Ecowitt-gateway",
+        "description": "Opdater forbindelsesoplysningerne for denne gateway, for eksempel efter at dens IP-adresse er ændret.",
+        "data": {
+          "host": "Gatewayens IP-adresse",
+          "password": "Gatewayens adgangskode (valgfri)"
+        },
+        "data_description": {
+          "host": "Ecowitt-gatewayens IP-adresse eller værtsnavn (f.eks. 192.168.1.100)",
+          "password": "Adgangskode til gatewayens webinterface (lad feltet stå tomt, hvis der ikke er en adgangskode)"
+        }
       }
     },
     "error": {
@@ -34,7 +46,9 @@
       "unknown": "Der opstod en uventet fejl. Prøv igen."
     },
     "abort": {
-      "already_configured": "Denne gateway er allerede konfigureret."
+      "already_configured": "Denne gateway er allerede konfigureret.",
+      "reconfigure_successful": "Forbindelsen til gatewayen blev opdateret.",
+      "wrong_device": "Denne IP-adresse tilhører en anden gateway end den, der aktuelt er konfigureret for denne post. Kontrollér adressen, eller fjern denne integration, og tilføj den anden gateway separat."
     }
   },
   "options": {

--- a/custom_components/ecowitt_local/translations/en.json
+++ b/custom_components/ecowitt_local/translations/en.json
@@ -26,6 +26,18 @@
           "mapping_interval": "How often to refresh sensor mappings (300-3600 seconds)",
           "include_inactive": "Include sensors that are currently offline or have no data"
         }
+      },
+      "reconfigure": {
+        "title": "Update Ecowitt Gateway Connection",
+        "description": "Update the connection details for this gateway, for example after its IP address changed.",
+        "data": {
+          "host": "Gateway IP Address",
+          "password": "Gateway Password (optional)"
+        },
+        "data_description": {
+          "host": "IP address or hostname of the Ecowitt gateway (e.g., 192.168.1.100)",
+          "password": "Password for the gateway web interface (leave blank if none)"
+        }
       }
     },
     "error": {
@@ -34,7 +46,9 @@
       "unknown": "Unexpected error occurred. Please try again."
     },
     "abort": {
-      "already_configured": "This gateway is already configured."
+      "already_configured": "This gateway is already configured.",
+      "reconfigure_successful": "The gateway connection was updated successfully.",
+      "wrong_device": "This IP address belongs to a different gateway than the one currently configured for this entry. Double-check the address, or remove this integration and add the other gateway separately."
     }
   },
   "options": {

--- a/custom_components/ecowitt_local/translations/fr.json
+++ b/custom_components/ecowitt_local/translations/fr.json
@@ -26,6 +26,18 @@
           "mapping_interval": "Fréquence de rafraîchissement du mappage des capteurs (300 à 3600 secondes)",
           "include_inactive": "Inclure les capteurs actuellement hors ligne ou sans données"
         }
+      },
+      "reconfigure": {
+        "title": "Mettre à jour la connexion à la passerelle Ecowitt",
+        "description": "Mettez à jour les détails de connexion de cette passerelle, par exemple après un changement de son adresse IP.",
+        "data": {
+          "host": "Adresse IP de la passerelle",
+          "password": "Mot de passe de la passerelle (facultatif)"
+        },
+        "data_description": {
+          "host": "Adresse IP ou nom d'hôte de la passerelle Ecowitt (ex. : 192.168.1.100)",
+          "password": "Mot de passe pour l'interface web de la passerelle (laisser vide si aucun)"
+        }
       }
     },
     "error": {
@@ -34,7 +46,9 @@
       "unknown": "Une erreur inattendue est survenue. Veuillez réessayer."
     },
     "abort": {
-      "already_configured": "Cette passerelle est déjà configurée."
+      "already_configured": "Cette passerelle est déjà configurée.",
+      "reconfigure_successful": "La connexion à la passerelle a été mise à jour avec succès.",
+      "wrong_device": "Cette adresse IP appartient à une passerelle différente de celle actuellement configurée pour cette entrée. Vérifiez l'adresse, ou supprimez cette intégration et ajoutez l'autre passerelle séparément."
     }
   },
   "options": {

--- a/custom_components/ecowitt_local/translations/it.json
+++ b/custom_components/ecowitt_local/translations/it.json
@@ -26,6 +26,18 @@
           "mapping_interval": "Ogni quanto aggiornare il mapping dei sensori (300-3600 secondi)",
           "include_inactive": "Includi i sensori attualmente offline o senza dati"
         }
+      },
+      "reconfigure": {
+        "title": "Aggiorna Connessione Gateway Ecowitt",
+        "description": "Aggiorna i dettagli di connessione di questo Gateway, ad esempio dopo un cambio del suo indirizzo IP.",
+        "data": {
+          "host": "Indirizzo IP del Gateway",
+          "password": "Password del Gateway (opzionale)"
+        },
+        "data_description": {
+          "host": "Indirizzo IP o hostname del Gateway Ecowitt (es. 192.168.1.100)",
+          "password": "Password per l'interfaccia web del Gateway (lasciare vuoto se assente)"
+        }
       }
     },
     "error": {
@@ -34,7 +46,9 @@
       "unknown": "Si è verificato un errore imprevisto. Riprova."
     },
     "abort": {
-      "already_configured": "Questo Gateway è già configurato."
+      "already_configured": "Questo Gateway è già configurato.",
+      "reconfigure_successful": "La connessione al Gateway è stata aggiornata con successo.",
+      "wrong_device": "Questo indirizzo IP appartiene a un Gateway diverso da quello attualmente configurato per questa voce. Verifica l'indirizzo, oppure rimuovi questa integrazione e aggiungi l'altro Gateway separatamente."
     }
   },
   "options": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -402,6 +402,11 @@ def mock_ecowitt_api():
     mock_instance.get_all_sensor_mappings = AsyncMock(return_value=[])
     mock_instance.get_soil_calibration = AsyncMock(return_value=[])
     mock_instance.get_lds_config = AsyncMock(return_value=[])
+    # No MAC by default — an unconfigured mock would otherwise auto-generate
+    # a truthy MagicMock for `.get("mac")`, which would be misread as a real
+    # MAC address by config_flow.validate_input. Tests that exercise the
+    # MAC-based unique_id path override this explicitly.
+    mock_instance.get_network_info = AsyncMock(return_value={})
 
     return mock_instance
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -208,6 +208,28 @@ async def test_get_version():
 
 
 @pytest.mark.asyncio
+async def test_get_network_info():
+    """Test getting network information (used for the gateway's MAC address)."""
+    api = EcowittLocalAPI("192.168.1.100", "")
+
+    mock_data = {
+        "mac": "24:4C:AB:6C:37:D1",
+        "ssid": "MyWiFi",
+        "wifi_ip": "192.168.1.100",
+    }
+
+    with aioresponses() as m:
+        m.get("http://192.168.1.100/get_network_info", payload=mock_data)
+
+        result = await api.get_network_info()
+
+        assert result == mock_data
+        assert result["mac"] == "24:4C:AB:6C:37:D1"
+
+    await api.close()
+
+
+@pytest.mark.asyncio
 async def test_test_connection():
     """Test connection test."""
     api = EcowittLocalAPI("192.168.1.100", "")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,8 +8,15 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.ecowitt_local.config_flow import CannotConnect, InvalidAuth
+from custom_components.ecowitt_local.api import EcowittLocalAPIError
+from custom_components.ecowitt_local.config_flow import (
+    CannotConnect,
+    InvalidAuth,
+    _looks_like_mac,
+    validate_input,
+)
 from custom_components.ecowitt_local.const import CONF_HOST, CONF_PASSWORD, DOMAIN
 
 
@@ -166,6 +173,413 @@ async def test_options_flow_reads_from_options_not_data(
     assert (
         schema_keys["include_inactive"].default() is True
     ), "Options form should show include_inactive=True from .options, not False from .data"
+
+
+async def test_form_uses_mac_when_available(
+    hass: HomeAssistant, mock_ecowitt_api
+) -> None:
+    """Test the unique_id is MAC-based when the gateway exposes /get_network_info."""
+    mock_ecowitt_api.get_network_info.return_value = {"mac": "24:4C:AB:6C:37:D1"}
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with (
+        patch(
+            "custom_components.ecowitt_local.config_flow.EcowittLocalAPI",
+            return_value=mock_ecowitt_api,
+        ),
+        patch(
+            "custom_components.ecowitt_local.coordinator.EcowittLocalAPI",
+            return_value=mock_ecowitt_api,
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "192.168.1.100", CONF_PASSWORD: "test_password"},
+        )
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {
+                "scan_interval": 60,
+                "mapping_interval": 600,
+                "include_inactive": False,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result3["type"] == FlowResultType.CREATE_ENTRY
+    assert result3["result"].unique_id == "24:4c:ab:6c:37:d1"
+
+
+async def test_validate_input_parses_model_without_stationtype(
+    hass: HomeAssistant, mock_ecowitt_api
+) -> None:
+    """Test validate_input falls back to parsing the model from the version string."""
+    mock_ecowitt_api.get_version.return_value = {"version": "Version: GW1100A_V2.4.5"}
+
+    with patch(
+        "custom_components.ecowitt_local.config_flow.EcowittLocalAPI",
+        return_value=mock_ecowitt_api,
+    ):
+        info = await validate_input(
+            hass, {CONF_HOST: "192.168.1.100", CONF_PASSWORD: ""}
+        )
+
+    assert info["model"] == "GW1100A"
+
+
+async def test_validate_input_network_info_unavailable(
+    hass: HomeAssistant, mock_ecowitt_api
+) -> None:
+    """Test validate_input falls back to model_host when /get_network_info fails."""
+    mock_ecowitt_api.get_network_info.side_effect = EcowittLocalAPIError("nope")
+
+    with patch(
+        "custom_components.ecowitt_local.config_flow.EcowittLocalAPI",
+        return_value=mock_ecowitt_api,
+    ):
+        info = await validate_input(
+            hass, {CONF_HOST: "192.168.1.100", CONF_PASSWORD: ""}
+        )
+
+    assert info["mac"] is None
+    assert info["unique_id"] == "GW1100A_192.168.1.100"
+
+
+async def test_reconfigure_flow_unknown_error(
+    hass: HomeAssistant, mock_ecowitt_api
+) -> None:
+    """Test the reconfigure flow surfaces unexpected errors without changing the entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.100", CONF_PASSWORD: "test_password"},
+        entry_id="reconfigure_entry_id",
+        unique_id="GW1100A_192.168.1.100",
+        title="Ecowitt Gateway (192.168.1.100)",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+
+    with patch(
+        "custom_components.ecowitt_local.config_flow.validate_input",
+        side_effect=ValueError("boom"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "192.168.1.200", CONF_PASSWORD: "test_password"},
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "unknown"}
+    assert entry.data[CONF_HOST] == "192.168.1.100"
+
+
+def test_looks_like_mac_falsy_unique_id() -> None:
+    """Test _looks_like_mac returns False for None/empty unique_id (no legacy entry yet)."""
+    assert _looks_like_mac(None) is False
+    assert _looks_like_mac("") is False
+
+
+async def test_reconfigure_flow_updates_host(
+    hass: HomeAssistant, mock_ecowitt_api
+) -> None:
+    """Test the reconfigure flow updates the host on the same entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.100", CONF_PASSWORD: "test_password"},
+        entry_id="reconfigure_entry_id",
+        unique_id="GW1100A_192.168.1.100",
+        title="Ecowitt Gateway (192.168.1.100)",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    with (
+        patch(
+            "custom_components.ecowitt_local.config_flow.EcowittLocalAPI",
+            return_value=mock_ecowitt_api,
+        ),
+        patch("custom_components.ecowitt_local.async_unload_entry", return_value=True),
+        patch("custom_components.ecowitt_local.async_setup_entry", return_value=True),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "192.168.1.200", CONF_PASSWORD: "test_password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "reconfigure_successful"
+
+    updated_entry = hass.config_entries.async_get_entry("reconfigure_entry_id")
+    assert updated_entry is not None
+    assert updated_entry.data[CONF_HOST] == "192.168.1.200"
+    assert updated_entry.unique_id == "GW1100A_192.168.1.200"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+
+async def test_reconfigure_flow_cannot_connect(
+    hass: HomeAssistant, mock_ecowitt_api
+) -> None:
+    """Test the reconfigure flow shows an error and leaves the entry untouched."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.100", CONF_PASSWORD: "test_password"},
+        entry_id="reconfigure_entry_id",
+        unique_id="GW1100A_192.168.1.100",
+        title="Ecowitt Gateway (192.168.1.100)",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+
+    with patch(
+        "custom_components.ecowitt_local.config_flow.validate_input",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "192.168.1.999", CONF_PASSWORD: ""},
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+    assert entry.data[CONF_HOST] == "192.168.1.100"
+
+
+async def test_reconfigure_flow_invalid_auth(
+    hass: HomeAssistant, mock_ecowitt_api
+) -> None:
+    """Test the reconfigure flow surfaces invalid-auth errors without changing the entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.100", CONF_PASSWORD: "test_password"},
+        entry_id="reconfigure_entry_id",
+        unique_id="GW1100A_192.168.1.100",
+        title="Ecowitt Gateway (192.168.1.100)",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+
+    with patch(
+        "custom_components.ecowitt_local.config_flow.validate_input",
+        side_effect=InvalidAuth,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "192.168.1.100", CONF_PASSWORD: "wrong_password"},
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "invalid_auth"}
+    assert entry.data[CONF_PASSWORD] == "test_password"
+
+
+async def test_reconfigure_flow_conflicts_with_other_entry(
+    hass: HomeAssistant, mock_ecowitt_api
+) -> None:
+    """Test reconfiguring toward a host already claimed by a different entry aborts."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.100", CONF_PASSWORD: "test_password"},
+        entry_id="reconfigure_entry_id",
+        unique_id="GW1100A_192.168.1.100",
+        title="Ecowitt Gateway (192.168.1.100)",
+    )
+    entry.add_to_hass(hass)
+
+    other_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.200", CONF_PASSWORD: ""},
+        entry_id="other_entry_id",
+        unique_id="GW1100A_192.168.1.200",
+        title="Ecowitt Gateway (192.168.1.200)",
+    )
+    other_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+
+    with patch(
+        "custom_components.ecowitt_local.config_flow.EcowittLocalAPI",
+        return_value=mock_ecowitt_api,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "192.168.1.200", CONF_PASSWORD: "test_password"},
+        )
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"
+    assert entry.data[CONF_HOST] == "192.168.1.100"
+
+
+async def test_reconfigure_flow_upgrades_legacy_unique_id_to_mac(
+    hass: HomeAssistant, mock_ecowitt_api
+) -> None:
+    """Test a legacy entry can adopt a MAC-based unique_id without a false wrong_device abort."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.100", CONF_PASSWORD: "test_password"},
+        entry_id="reconfigure_entry_id",
+        unique_id="unknown_192.168.1.100",
+        title="Ecowitt Gateway (192.168.1.100)",
+    )
+    entry.add_to_hass(hass)
+
+    mock_ecowitt_api.get_network_info.return_value = {"mac": "24:4C:AB:6C:37:D1"}
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+
+    with (
+        patch(
+            "custom_components.ecowitt_local.config_flow.EcowittLocalAPI",
+            return_value=mock_ecowitt_api,
+        ),
+        patch("custom_components.ecowitt_local.async_unload_entry", return_value=True),
+        patch("custom_components.ecowitt_local.async_setup_entry", return_value=True),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "192.168.1.100", CONF_PASSWORD: "test_password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "reconfigure_successful"
+
+    updated_entry = hass.config_entries.async_get_entry("reconfigure_entry_id")
+    assert updated_entry is not None
+    assert updated_entry.unique_id == "24:4c:ab:6c:37:d1"
+
+
+async def test_reconfigure_flow_wrong_device_abort(
+    hass: HomeAssistant, mock_ecowitt_api
+) -> None:
+    """Test reconfiguring toward a gateway with a different MAC aborts as wrong_device."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.100", CONF_PASSWORD: "test_password"},
+        entry_id="reconfigure_entry_id",
+        unique_id="24:4c:ab:6c:37:d1",
+        title="Ecowitt Gateway (192.168.1.100)",
+    )
+    entry.add_to_hass(hass)
+
+    mock_ecowitt_api.get_network_info.return_value = {"mac": "AA:BB:CC:DD:EE:FF"}
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+
+    with patch(
+        "custom_components.ecowitt_local.config_flow.EcowittLocalAPI",
+        return_value=mock_ecowitt_api,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "192.168.1.200", CONF_PASSWORD: "test_password"},
+        )
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "wrong_device"
+
+    unchanged_entry = hass.config_entries.async_get_entry("reconfigure_entry_id")
+    assert unchanged_entry is not None
+    assert unchanged_entry.data[CONF_HOST] == "192.168.1.100"
+    assert unchanged_entry.unique_id == "24:4c:ab:6c:37:d1"
+
+
+async def test_reconfigure_flow_same_device_new_ip(
+    hass: HomeAssistant, mock_ecowitt_api
+) -> None:
+    """Test reconfiguring to a new IP succeeds when the MAC still matches."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.100", CONF_PASSWORD: "test_password"},
+        entry_id="reconfigure_entry_id",
+        unique_id="24:4c:ab:6c:37:d1",
+        title="Ecowitt Gateway (192.168.1.100)",
+    )
+    entry.add_to_hass(hass)
+
+    mock_ecowitt_api.get_network_info.return_value = {"mac": "24:4C:AB:6C:37:D1"}
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+
+    with (
+        patch(
+            "custom_components.ecowitt_local.config_flow.EcowittLocalAPI",
+            return_value=mock_ecowitt_api,
+        ),
+        patch("custom_components.ecowitt_local.async_unload_entry", return_value=True),
+        patch("custom_components.ecowitt_local.async_setup_entry", return_value=True),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "192.168.1.200", CONF_PASSWORD: "test_password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "reconfigure_successful"
+
+    updated_entry = hass.config_entries.async_get_entry("reconfigure_entry_id")
+    assert updated_entry is not None
+    assert updated_entry.data[CONF_HOST] == "192.168.1.200"
+    assert updated_entry.unique_id == "24:4c:ab:6c:37:d1"
 
 
 async def test_complete_flow(hass: HomeAssistant, mock_ecowitt_api) -> None:


### PR DESCRIPTION
Lets the gateway's IP address (and password) be updated from the Home Assistant UI after a DHCP lease change, without removing and re-adding the integration. The config entry's unique_id is now based on the gateway's MAC address (via /get_network_info) when available, since it survives IP changes unlike the previous model+host scheme; legacy entries adopt it transparently on first reconfigure. Also fixes the config flow always reporting the model as "Unknown" on gateways that omit stationtype from /get_version, by reusing the firmware-string parsing already used for the live gateway device info.